### PR TITLE
Support for upcoming smart-contract-based allocators.

### DIFF
--- a/fplus-database/src/database/allocators.rs
+++ b/fplus-database/src/database/allocators.rs
@@ -23,6 +23,8 @@ pub async fn get_allocators() ->Result<Vec<AllocatorModel>, sea_orm::DbErr> {
  * @param multisig_address: Option<String> - The multisig address
  * @param verifiers_gh_handles: Option<String> - The GitHub handles of the verifiers
  * @param multisig_threshold: Option<i32> - The multisig threshold
+ * @param address: Option<String> - Address of the Allocator
+ * @param tooling: Option<String> - Supported tooling
  * 
  * # Returns
  * @return Result<AllocatorModel, sea_orm::DbErr> - The result of the operation
@@ -33,7 +35,9 @@ pub async fn update_allocator(
     installation_id: Option<i64>,
     multisig_address: Option<String>,
     verifiers_gh_handles: Option<String>,
-    multisig_threshold: Option<i32>
+    multisig_threshold: Option<i32>,
+    address: Option<String>,
+    tooling: Option<String>,
 ) -> Result<AllocatorModel, sea_orm::DbErr> {
     let conn = get_database_connection().await?;
 
@@ -45,7 +49,7 @@ pub async fn update_allocator(
         if Some(installation_id) != None {
             allocator_active_model.installation_id = Set(installation_id);
         }
-        
+
         if Some(multisig_address.clone()) != None {
             allocator_active_model.multisig_address = Set(multisig_address);
         }
@@ -56,6 +60,14 @@ pub async fn update_allocator(
 
         if Some(multisig_threshold) != None {
             allocator_active_model.multisig_threshold = Set(multisig_threshold);
+        }
+
+        if address.is_some() {
+            allocator_active_model.address = Set(address);
+        }
+
+        if tooling.is_some() {
+            allocator_active_model.tooling = Set(tooling);
         }
 
         let updated_model = allocator_active_model.update(&conn).await?;
@@ -97,6 +109,8 @@ pub async fn get_allocator(
  * @param installation_id: Option<i64> - The installation ID
  * @param multisig_address: Option<String> - The multisig address
  * @param verifiers_gh_handles: Option<String> - The GitHub handles of the verifiers
+ * @param address: Option<String> - Address of the Allocator
+ * @param tooling: Option<String> - Supported tooling
  * 
  * # Returns
  * @return Result<AllocatorModel, sea_orm::DbErr> - The result of the operation
@@ -108,7 +122,9 @@ pub async fn create_or_update_allocator(
     multisig_address: Option<String>,
     verifiers_gh_handles: Option<String>,
     multisig_threshold: Option<i32>,
-    allocation_amount_type: Option<String>
+    allocation_amount_type: Option<String>,
+    address: Option<String>,
+    tooling: Option<String>,
 ) -> Result<AllocatorModel, sea_orm::DbErr> {
 
     let existing_allocator = get_allocator(&owner, &repo).await?;
@@ -136,6 +152,14 @@ pub async fn create_or_update_allocator(
             allocator_active_model.allocation_amount_type = Set(Some(allocation_amount_type.to_lowercase()));
         } else {
             allocator_active_model.allocation_amount_type = Set(None);
+        }
+
+        if address.is_some() {
+            allocator_active_model.address = Set(address);
+        }
+
+        if tooling.is_some() {
+            allocator_active_model.tooling = Set(tooling);
         }
 
         let updated_model = allocator_active_model.update(&conn).await?;
@@ -168,6 +192,14 @@ pub async fn create_or_update_allocator(
             new_allocator.allocation_amount_type = Set(Some(allocation_amount_type.to_lowercase()));
         } else {
             new_allocator.allocation_amount_type = Set(None);
+        }
+
+        if address.is_some() {
+            new_allocator.address = Set(address);
+        }
+
+        if tooling.is_some() {
+            new_allocator.tooling = Set(tooling);
         }
 
         let conn = get_database_connection().await.expect("Failed to get DB connection");

--- a/fplus-database/src/lib.rs
+++ b/fplus-database/src/lib.rs
@@ -105,6 +105,8 @@ mod tests {
         let verifiers_gh_handles = Some("test_verifier_1, test_verifier_2".to_string());
         let multisig_threshold = Some(2);
         let amount_type = Some("Fixed".to_string());
+        let address = Some("0x1234567890".to_string());
+        let tooling = Some("common_ui, smart_contract_allocator".to_string());
 
         let result = database::allocators::create_or_update_allocator(
             owner,
@@ -113,7 +115,9 @@ mod tests {
             multisig_address,
             verifiers_gh_handles,
             multisig_threshold,
-            amount_type
+            amount_type,
+            address,
+            tooling
         ).await;
         assert!(result.is_ok());
     }
@@ -156,6 +160,8 @@ mod tests {
             let verifiers_gh_handles = Some("test_verifier_1, test_verifier_2".to_string());
             let multisig_threshold = Some(2);
             let amount_type = Some("Fixed".to_string());
+            let address = Some("0x1234567890".to_string());
+            let tooling = Some("common_ui, smart_contract_allocator".to_string());
 
             let result = database::allocators::create_or_update_allocator(
                 owner.clone(),
@@ -164,7 +170,9 @@ mod tests {
                 multisig_address,
                 verifiers_gh_handles,
                 multisig_threshold,
-                amount_type
+                amount_type,
+                address,
+                tooling,
             ).await;
             assert!(result.is_ok());
         }
@@ -175,6 +183,8 @@ mod tests {
         let multisig_address = Some("0x0987654321".to_string());
         let verifiers_gh_handles = Some("test_verifier_3, test_verifier_4".to_string());
         let multisig_threshold = Some(1);
+        let address = Some("0xababababa".to_string());
+        let tooling = Some("common_ui".to_string());
 
         let result = database::allocators::update_allocator(
             &owner,
@@ -182,7 +192,9 @@ mod tests {
             installation_id,
             multisig_address,
             verifiers_gh_handles,
-            multisig_threshold
+            multisig_threshold,
+            address,
+            tooling
         ).await;
         assert!(result.is_ok());
     }
@@ -229,6 +241,8 @@ mod tests {
         let verifiers_gh_handles = Some("test_verifier_1, test_verifier_2".to_string());
         let multisig_threshold = Some(2);
         let amount_type = Some("Fixed".to_string());
+        let address = Some("0x1234567890".to_string());
+        let tooling = Some("common_ui, smart_contract_allocator".to_string());
 
         let result = database::allocators::create_or_update_allocator(
             owner.clone(),
@@ -237,7 +251,9 @@ mod tests {
             multisig_address,
             verifiers_gh_handles,
             multisig_threshold,
-            amount_type
+            amount_type,
+            address,
+            tooling,
         ).await;
 
         assert!(result.is_ok());

--- a/fplus-database/src/models/allocators.rs
+++ b/fplus-database/src/models/allocators.rs
@@ -16,6 +16,8 @@ pub struct Model {
     pub verifiers_gh_handles: Option<String>,
     pub multisig_threshold: Option<i32>,
     pub allocation_amount_type: Option<String>,
+    pub address: Option<String>,
+    pub tooling: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter)]

--- a/fplus-http-server/src/router/allocator.rs
+++ b/fplus-http-server/src/router/allocator.rs
@@ -66,6 +66,11 @@ pub async fn create_from_json(files: web::Json<ChangedAllocators>) -> actix_web:
                 } else {
                     Some(model.application.verifiers_gh_handles.join(", ")) // Join verifiers in a string if exists
                 };
+                let tooling = if model.application.tooling.is_empty() {
+                    None
+                } else {
+                    Some(model.application.tooling.join(", "))
+                };
                 let owner = model.owner.clone().unwrap_or_default().to_string();
                 let repo = model.repo.clone().unwrap_or_default().to_string();
 
@@ -76,7 +81,9 @@ pub async fn create_from_json(files: web::Json<ChangedAllocators>) -> actix_web:
                     Some(model.pathway_addresses.msig),      
                     verifiers_gh_handles,
                     model.multisig_threshold,
-                    model.application.allocation_amount.clone().map(|a| a.amount_type.clone()).flatten() // Flattens Option<Option<String>> to Option<String>
+                    model.application.allocation_amount.clone().map(|a| a.amount_type.clone()).flatten(), // Flattens Option<Option<String>> to Option<String>
+                    model.address,
+                    tooling,
                 ).await;
 
                 match allocator_creation_result {
@@ -167,7 +174,9 @@ pub async fn update(
         None,
         info.multisig_address.clone(),
         info.verifiers_gh_handles.clone(),
-        info.multisig_threshold
+        info.multisig_threshold,
+        info.address.clone(),
+        info.tooling.clone(),
     ).await {
         Ok(allocator_model) => HttpResponse::Ok().json(allocator_model),
         Err(e) => {

--- a/fplus-lib/src/core/allocator/file.rs
+++ b/fplus-lib/src/core/allocator/file.rs
@@ -7,6 +7,7 @@ pub struct AllocatorModel {
     pub pathway_addresses: AllocatorModelPathwayAddresses,
     pub owner: Option<String>,
     pub repo: Option<String>,
+    pub address: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -21,6 +22,7 @@ pub struct Application {
     pub verifiers_gh_handles: Vec<String>,
     pub allocation_bookkeeping: String,
     pub allocation_amount: Option<AllocationAmount>,
+    pub tooling: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/fplus-lib/src/core/allocator/mod.rs
+++ b/fplus-lib/src/core/allocator/mod.rs
@@ -278,7 +278,7 @@ pub async fn update_installation_ids_in_db(installation: InstallationRepositorie
     for repo in installation.repositories.iter() {
         let owner = repo.owner.clone();
         let repo = repo.slug.clone();
-        let _ = create_or_update_allocator(owner, repo, Some(installation_id.try_into().unwrap()), None, None, None, None).await;
+        let _ = create_or_update_allocator(owner, repo, Some(installation_id.try_into().unwrap()), None, None, None, None, None, None).await;
     }
 }
 

--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -136,6 +136,8 @@ pub struct AllocatorUpdateInfo {
     pub multisig_address: Option<String>,
     pub verifiers_gh_handles: Option<String>,
     pub multisig_threshold: Option<i32>,
+    pub address: Option<String>,
+    pub tooling: Option<String>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
# Pull Request Template

## Description

**What**: this PR stores "address" and "tooling" fields from allocator JSON files in database and exposes to clients via API.

**Why**: smart-contract allocators will need to make a different call on-chain to grant datacap to a client. Instead of calling verifreg directly, they'll need to call smart contract which will do it on their behalf. Address of this smart contract is stored in the "address" field and we need the "tooling" field to know when to use the new approach.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. I've setup my own "Allocator-Governance" repo with some JSONs in it: https://github.com/Neti-Test/filplus-allocator-governance/tree/main/active
2. Configured the backend to use this repo
3. `curl -H "Content-Type: application/json" -d '{"files_changed":["active/msig-classic.json","active/msig-contract.json"]}'  localhost:8080/allocator/create`
    * NOTE - it did fail to me at this point due to null installation_id of the allocator. This seems unrelated to my changes though and I've worked it around by setting the installation_id manually in the DB and rerunning the create endpoint.
5. `curl -s localhost:8080/allocators`, verified that it now includes `address` and `tooling` in the response.

## Checklist:

Before submitting your pull request, please review the following checklist:

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation. - No, please point me to the documentation that potentially needs to be updated.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.

## Additional Information

I'm not sure if this change needs a change to documentation. Is there a documentation somewhere?
I also weren't able to run `fplus-lib` tests as they seem to depend on some specific repo (`keyko-io/test-philip-second`). Please provide some guidance if you deem it necessary for this change.

Also this needs a database schema migration, to add `address` and `tooling` text columns to `allocators` table. How should this be handled?
