### PR TITLE
Endpoint: Trigger SSA

### DIFF
--- a/fplus-http-server/src/main.rs
+++ b/fplus-http-server/src/main.rs
@@ -96,6 +96,7 @@ async fn main() -> std::io::Result<()> {
             .service(router::application::delete_branch)
             .service(router::application::cache_renewal)
             .service(router::application::update_from_issue)
+            .service(router::application::trigger_ssa)
             .service(router::blockchain::address_allowance)
             .service(router::blockchain::verified_clients)
             .service(router::verifier::verifiers)

--- a/fplus-http-server/src/router/application.rs
+++ b/fplus-http-server/src/router/application.rs
@@ -1,6 +1,6 @@
 use actix_web::{get, post, web, HttpResponse, Responder};
 use fplus_lib::core::{
-        application::file::VerifierInput, ApplicationQueryParams, BranchDeleteInfo, CompleteGovernanceReviewInfo, CompleteNewApplicationApprovalInfo, CompleteNewApplicationProposalInfo, CreateApplicationInfo, DcReachedInfo, GithubQueryParams, LDNApplication, MoreInfoNeeded, RefillInfo, ValidationPullRequestData, VerifierActionsQueryParams
+        application::file::VerifierInput, ApplicationQueryParams, BranchDeleteInfo, CompleteGovernanceReviewInfo, CompleteNewApplicationApprovalInfo, CompleteNewApplicationProposalInfo, CreateApplicationInfo, DcReachedInfo, GithubQueryParams, LDNApplication, MoreInfoNeeded, RefillInfo, ValidationPullRequestData, VerifierActionsQueryParams, TriggerSSAInfo
     };
 
 
@@ -22,7 +22,6 @@ pub async fn single(
     query: web::Query<ApplicationQueryParams>,
 ) -> impl Responder {
     let ApplicationQueryParams { id, owner, repo } = query.into_inner();
-
     match LDNApplication::load_from_db(id, owner, repo).await {
         Ok(app_file) => {
             return HttpResponse::Ok().body(serde_json::to_string_pretty(&app_file).unwrap())
@@ -455,4 +454,14 @@ pub async fn check_for_changes(
 #[get("/health")]
 pub async fn health() -> impl Responder {
     HttpResponse::Ok().body("OK")
+}
+
+#[post("application/trigger_ssa")]
+pub async fn trigger_ssa(info: web::Json<TriggerSSAInfo>) -> impl Responder {
+    match LDNApplication::trigger_ssa(info.into_inner()).await {
+        Ok(()) => {
+            return HttpResponse::Ok().body(serde_json::to_string_pretty("Success").unwrap())
+        }
+        Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
+    };
 }

--- a/fplus-lib/src/core/application/allocation.rs
+++ b/fplus-lib/src/core/application/allocation.rs
@@ -3,6 +3,7 @@ use chrono::Utc;
 use super::file::{
     Allocation, AllocationRequest, AllocationRequestType, Allocations, Verifiers, Verifier,
 };
+use crate::helpers::parse_size_to_bytes;
 
 impl Default for Verifiers {
     fn default() -> Self {
@@ -137,5 +138,15 @@ impl Allocations {
         let allocation = Allocation::new(request);
         self.0.push(allocation);
         self.clone()
+    }
+
+    pub fn total_requested(&self) -> u64 {
+        let mut total_amount: u64 = 0;
+        for allocation in self.0.iter() {
+            if let Some(amount) = parse_size_to_bytes(&allocation.amount) {
+                total_amount += amount;
+            }
+        }
+        return total_amount;
     }
 }

--- a/fplus-lib/src/core/application/file.rs
+++ b/fplus-lib/src/core/application/file.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 
+use futures::stream::All;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -337,6 +338,11 @@ impl ApplicationFile {
             // Return an error if no active allocation is found
             Err("No active allocation found")
         }
+    }
+
+    pub fn get_last_request_allowance(&self) -> Option<Allocation> {
+        let request_id = self.lifecycle.active_request.clone()?;
+        self.allocation.find_one(request_id)
     }
 }
 

--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         blockchain::BlockchainData, filecoin::get_multisig_threshold_for_actor, github::{
             github_async_new, CreateMergeRequestData, CreateRefillMergeRequestData, GithubWrapper,
         }
-    }, helpers::{compare_allowance_and_allocation, process_amount}, parsers::ParsedIssue
+    }, helpers::{compare_allowance_and_allocation, process_amount, parse_size_to_bytes}, parsers::ParsedIssue
 };
 use fplus_database::database::allocation_amounts::get_allocation_quantity_options;
 use fplus_database::database::{
@@ -43,6 +43,15 @@ pub struct CreateApplicationInfo {
     pub issue_number: String,
     pub owner: String,
     pub repo: String,
+}
+
+#[derive(Deserialize)]
+pub struct TriggerSSAInfo {
+    pub id: String,
+    pub owner: String,
+    pub repo: String,
+    pub amount: String,
+    pub amount_type: String,
 }
 
 #[derive(Deserialize)]
@@ -3523,6 +3532,46 @@ _The initial issue can be edited in order to solve the request of the verifier. 
         ).await;
 
         Ok(updated_application) // Return the updated ApplicationFile
+    }
+
+    pub async fn trigger_ssa(info: TriggerSSAInfo) -> Result<(), LDNError> {
+        let app_model =
+            Self::get_application_model(info.id.clone(), info.owner.clone(), info.repo.clone())
+                .await?;
+
+        let app_str = app_model.application.ok_or_else(|| {
+            LDNError::Load(format!(
+                "Application {} does not have an application field",
+                info.id
+            ))
+        })?;
+        let application_file = serde_json::from_str::<ApplicationFile>(&app_str).unwrap();
+
+        if application_file.lifecycle.state != AppState::Granted {
+            return Err(LDNError::Load(format!("Application state is {:?}. Expected Granted", application_file.lifecycle.state)));
+        }
+        let last_allocation = application_file.get_last_request_allowance().ok_or(LDNError::Load("Last allocation not found".into()))?;
+        if last_allocation.is_active {
+            return Err(LDNError::Load("Last active allocation ID is active".into()));
+        }
+
+        let requested_so_far = application_file.allocation.total_requested();
+        let total_requested = parse_size_to_bytes(&application_file.datacap.total_requested_amount).ok_or(
+            LDNError::Load("Can not parse total requested amount to bytes".into()),
+            )?;
+        
+        if requested_so_far >= total_requested {
+            return Err(LDNError::Load("Total datacap reached".into()));
+        }
+        let refill_info = RefillInfo {
+            id: info.id,
+            amount: info.amount,
+            amount_type: info.amount_type,
+            owner: app_model.owner,
+            repo: app_model.repo,
+        };
+        Self::refill(refill_info).await?;
+        Ok(())
     }
 }
 

--- a/fplus-lib/src/helpers.rs
+++ b/fplus-lib/src/helpers.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-fn parse_size_to_bytes(size: &str) -> Option<u64> {
+pub fn parse_size_to_bytes(size: &str) -> Option<u64> {
   let re = Regex::new(r"^(\d+)([a-zA-Z]+)$").unwrap();
   let caps = re.captures(size.trim())?;
 


### PR DESCRIPTION
## Endpoint: application/trigger_ssa

**Description:**
The `application/trigger_ssa` endpoint checks, based on the data received (`TriggerSSAInfo`), the current state of the application. If the conditions are met, it calls the `refill` function.

It will be used by filplus-registry to provide a manual way to trigger SSA flow in case the SSA bot fails. It's basically the `/application/refill` endpoint, but with some additional checks (see **Usage Conditions**) to make sure we don't trigger it when we shouldn't.

**Usage Conditions:**
To execute this endpoint, the following conditions must be met:
1. The application must be in the `Granted` state.
2. The Last active allocation ID must not be active.
3. The total allocated amount can't be greater than or equal to the total requested amount.

**Impact on Application Lifecycle:**
It will add a comment on the relevant GitHub issue and change the label to `refill`.

**Deployment Considerations:**
No special actions are required.

**Example TriggerSSAInfo:**
```json
{
  "id": "client_address",
  "owner": "owner_name",
  "repo": "repo_name",
  "amount": "1",
  "amount_type": "PiB"
}
