### PR TITLE
Request KYC endpoint

### DIFF
--- a/fplus-http-server/src/main.rs
+++ b/fplus-http-server/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> std::io::Result<()> {
                     .service(router::application::approve)
                     .service(router::application::decline)
                     .service(router::application::additional_info_required)
+                    .service(router::application::request_kyc)
             )
             .service(router::application::merged)
             .service(router::application::active)

--- a/fplus-http-server/src/router/application.rs
+++ b/fplus-http-server/src/router/application.rs
@@ -465,7 +465,6 @@ pub async fn request_kyc(
         {
             Ok(app) => app,
             Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
-
         };
     match ldn_application.request_kyc(info.into_inner()).await {
         Ok(()) => {

--- a/fplus-http-server/src/router/application.rs
+++ b/fplus-http-server/src/router/application.rs
@@ -1,6 +1,6 @@
 use actix_web::{get, post, web, HttpResponse, Responder};
 use fplus_lib::core::{
-        application::file::VerifierInput, ApplicationQueryParams, BranchDeleteInfo, CompleteGovernanceReviewInfo, CompleteNewApplicationApprovalInfo, CompleteNewApplicationProposalInfo, CreateApplicationInfo, DcReachedInfo, GithubQueryParams, LDNApplication, MoreInfoNeeded, RefillInfo, ValidationPullRequestData, VerifierActionsQueryParams, KYCRequestedInfo, TriggerSSAInfo
+        application::file::VerifierInput, ApplicationQueryParams, BranchDeleteInfo, CompleteGovernanceReviewInfo, CompleteNewApplicationApprovalInfo, CompleteNewApplicationProposalInfo, CreateApplicationInfo, DcReachedInfo, GithubQueryParams, LDNApplication, MoreInfoNeeded, RefillInfo, ValidationPullRequestData, VerifierActionsQueryParams, TriggerSSAInfo
     };
 
 
@@ -458,15 +458,15 @@ pub async fn health() -> impl Responder {
 
 #[post("application/request_kyc")]
 pub async fn request_kyc(
-    info: web::Json<KYCRequestedInfo>,
+    query: web::Query<VerifierActionsQueryParams>,
 ) -> impl Responder {
     let ldn_application =
-        match LDNApplication::load(info.id.clone(), info.owner.clone(), info.repo.clone()).await
+        match LDNApplication::load(query.id.clone(), query.owner.clone(), query.repo.clone()).await
         {
             Ok(app) => app,
             Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
         };
-    match ldn_application.request_kyc(info.into_inner()).await {
+    match ldn_application.request_kyc(&query.id, &query.owner, &query.repo).await {
         Ok(()) => {
             return HttpResponse::Ok().body(serde_json::to_string_pretty("Success").unwrap())
         }

--- a/fplus-lib/src/core/application/file.rs
+++ b/fplus-lib/src/core/application/file.rs
@@ -244,8 +244,8 @@ pub struct Provider {
 pub enum AppState {
     AdditionalInfoRequired,
     AdditionalInfoSubmitted,
-    Submitted,
     KYCRequested,
+    Submitted,
     ChangesRequested,
     ReadyToSign,
     StartSignDatacap,

--- a/fplus-lib/src/core/application/file.rs
+++ b/fplus-lib/src/core/application/file.rs
@@ -245,6 +245,7 @@ pub enum AppState {
     AdditionalInfoRequired,
     AdditionalInfoSubmitted,
     Submitted,
+    KYCRequested,
     ChangesRequested,
     ReadyToSign,
     StartSignDatacap,

--- a/fplus-lib/src/core/application/lifecycle.rs
+++ b/fplus-lib/src/core/application/lifecycle.rs
@@ -8,6 +8,7 @@ impl AppState {
             AppState::AdditionalInfoRequired => "additional information required",
             AppState::AdditionalInfoSubmitted => "additional information submitted",
             AppState::Submitted => "validated",
+            AppState::KYCRequested => "kyc requested",
             AppState::ChangesRequested => "application changes requested",
             AppState::ReadyToSign => "ready to sign",
             AppState::StartSignDatacap => "start sign datacap",
@@ -31,6 +32,14 @@ impl LifeCycle {
             client_on_chain_address,
             multisig_address,
             edited: Some(false)
+        }
+    }
+
+    pub fn kyc_request(&self) -> Self {
+        LifeCycle {
+            state: AppState::KYCRequested,
+            updated_at: Utc::now().to_string(),
+            ..self.clone()
         }
     }
 

--- a/fplus-lib/src/core/application/mod.rs
+++ b/fplus-lib/src/core/application/mod.rs
@@ -132,6 +132,17 @@ impl file::ApplicationFile {
             ..self.clone()
         }
     }
+
+    pub fn kyc_request(&mut self) -> Self {
+        let new_life_cycle = self
+            .lifecycle
+            .clone()
+            .kyc_request();
+        Self {
+            lifecycle: new_life_cycle,
+            ..self.clone()
+        }
+    }
 }
 
 impl std::str::FromStr for file::ApplicationFile {

--- a/fplus-lib/src/core/application/mod.rs
+++ b/fplus-lib/src/core/application/mod.rs
@@ -133,7 +133,7 @@ impl file::ApplicationFile {
         }
     }
 
-    pub fn kyc_request(&mut self) -> Self {
+    pub fn kyc_request(&self) -> Self {
         let new_life_cycle = self
             .lifecycle
             .clone()

--- a/fplus-lib/src/external_services/github.rs
+++ b/fplus-lib/src/external_services/github.rs
@@ -233,6 +233,7 @@ impl GithubWrapper {
         let search_labels = vec![
             "waiting for allocator review",
             AppState::Submitted.as_str(),
+            AppState::KYCRequested.as_str(),
             AppState::ReadyToSign.as_str(),
             AppState::StartSignDatacap.as_str(),
             AppState::Granted.as_str(),


### PR DESCRIPTION
## Endpoint: verifier/application/request_kyc

**Description:**
The functionality enables Allocators to request their clients to undergo the KYC process.

The `verifier/application/request_kyc` endpoint checks, based on the data received (`KYCRequestedInfo`), the current state of the application. If the condition is met, it:

- Updates the application's state to KYC requested.
- Updates the record in the database.
- Adds a comment on relevant GitHub issue and the label to `kyc requested`.
- Creates a commit with the updated application state on relevant branch.

**Usage Condition:**
To execute this endpoint, the following conditions must be met:

1. The application must be in the `Submitted` state.

**Deployment Considerations:**
-  new environment variable `KYC_URL` - variable should be set to the URL of the KYC portal

**Example KYCRequestedInfo:**

```json
{
  "id": "client_address",
  "owner": "owner_name",
  "repo": "repo_name"
}
```
