### PR TITLE
Remove pending allocation

### DIFF
--- a/fplus-http-server/src/main.rs
+++ b/fplus-http-server/src/main.rs
@@ -79,7 +79,8 @@ async fn main() -> std::io::Result<()> {
                     .service(router::application::decline)
                     .service(router::application::additional_info_required)
                     .service(router::application::trigger_ssa)
-                    .service(router::application::request_kyc),
+                    .service(router::application::request_kyc)
+                    .service(router::application::remove_pending_allocation),
             )
             .service(router::application::merged)
             .service(router::application::active)

--- a/fplus-http-server/src/router/application.rs
+++ b/fplus-http-server/src/router/application.rs
@@ -374,7 +374,7 @@ pub async fn validate_application_merge(
 #[post("/application/branch/delete")]
 pub async fn delete_branch(data: web::Json<BranchDeleteInfo>) -> actix_web::Result<impl Responder> {
     let info = data.into_inner();
-    match LDNApplication::delete_merged_branch(info.owner, info.repo, info.branch_name).await {
+    match LDNApplication::delete_branch(info.owner, info.repo, info.branch_name).await {
         Ok(result) => Ok(HttpResponse::Ok().json(result)),
         Err(e) => Ok(HttpResponse::BadRequest().body(e.to_string())),
     }
@@ -474,6 +474,25 @@ pub async fn trigger_ssa(
     info: web::Json<TriggerSSAInfo>,
 ) -> impl Responder {
     match LDNApplication::trigger_ssa(&query.id, &query.owner, &query.repo, info.into_inner()).await
+    {
+        Ok(()) => HttpResponse::Ok().body(serde_json::to_string_pretty("Success").unwrap()),
+        Err(e) => HttpResponse::BadRequest().body(e.to_string()),
+    }
+}
+
+#[post("application/remove_pending_allocation")]
+pub async fn remove_pending_allocation(
+    query: web::Query<VerifierActionsQueryParams>,
+) -> impl Responder {
+    let ldn_application =
+        match LDNApplication::load(query.id.clone(), query.owner.clone(), query.repo.clone()).await
+        {
+            Ok(app) => app,
+            Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
+        };
+    match ldn_application
+        .remove_pending_allocation(&query.id, &query.owner, &query.repo)
+        .await
     {
         Ok(()) => HttpResponse::Ok().body(serde_json::to_string_pretty("Success").unwrap()),
         Err(e) => HttpResponse::BadRequest().body(e.to_string()),

--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -1954,7 +1954,7 @@ impl LDNApplication {
 
     #[allow(clippy::too_many_arguments)]
     async fn update_and_commit_application_state(
-        self,
+        &self,
         db_application_file: ApplicationFile,
         owner: String,
         repo: String,
@@ -2140,8 +2140,7 @@ impl LDNApplication {
         branch_name: String,
         filename: String,
     ) -> Result<String, LDNError> {
-        Self::update_and_commit_application_state(
-            self,
+        self.update_and_commit_application_state(
             db_application_file.clone(),
             owner.clone(),
             repo.clone(),
@@ -2788,7 +2787,7 @@ impl LDNApplication {
         })
     }
 
-    pub async fn delete_merged_branch(
+    pub async fn delete_branch(
         owner: String,
         repo: String,
         branch_name: String,
@@ -3655,17 +3654,17 @@ _The initial issue can be edited in order to solve the request of the verifier. 
         }
 
         // Adjusted to capture the result of update_and_commit_application_state
-        let updated_application = Self::update_and_commit_application_state(
-            self,
-            db_application_file.clone(),
-            owner.clone(),
-            repo.clone(),
-            sha.clone(),
-            branch_name.clone(),
-            filename.clone(),
-            "Additional information required".to_string(),
-        )
-        .await?;
+        let updated_application = self
+            .update_and_commit_application_state(
+                db_application_file.clone(),
+                owner.clone(),
+                repo.clone(),
+                sha.clone(),
+                branch_name.clone(),
+                filename.clone(),
+                "Additional information required".to_string(),
+            )
+            .await?;
 
         let _ = Self::issue_additional_info_required(
             db_application_file.issue_number.clone(),
@@ -3957,6 +3956,138 @@ _The initial issue can be edited in order to solve the request of the verifier. 
             )));
         }
         Ok(address_from_signature)
+    }
+
+    pub async fn remove_pending_allocation(
+        &self,
+        client_id: &str,
+        owner: &str,
+        repo: &str,
+    ) -> Result<(), LDNError> {
+        let app_model =
+            Self::get_application_model(client_id.into(), owner.into(), repo.into()).await?;
+
+        if app_model.pr_number == 0 {
+            return Err(LDNError::Load("Active pull request not found".to_string()));
+        }
+
+        let app_str = &app_model.application.ok_or_else(|| {
+            LDNError::Load(format!(
+                "Application {} does not have an application field",
+                client_id
+            ))
+        })?;
+        let application_file = serde_json::from_str::<ApplicationFile>(app_str).unwrap();
+
+        if application_file.lifecycle.state != AppState::ReadyToSign {
+            return Err(LDNError::Load(format!(
+                "Application state is {:?}. Expected ReadyToSign",
+                application_file.lifecycle.state
+            )));
+        }
+        let last_allocation = application_file.get_active_allocation().ok_or_else(|| {
+            LDNError::Load(format!(
+                "Application {} does not have an active allocation",
+                client_id
+            ))
+        })?;
+
+        let is_first = last_allocation.request_type == "First";
+        if is_first {
+            self.remove_first_pending_allocation(&application_file)
+                .await?;
+        } else {
+            self.remove_pending_refill(&app_model.pr_number).await?;
+        }
+        self.issue_updates_after_removing_pending_allocation(
+            &application_file.issue_number,
+            is_first,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn issue_updates_after_removing_pending_allocation(
+        &self,
+        issue_number: &str,
+        is_first: bool,
+    ) -> Result<(), LDNError> {
+        let comment = format!(
+            "Last pending allocation reverted for an application `{}`.",
+            &self.application_id
+        );
+        let issue_number = issue_number.parse::<u64>().map_err(|e| {
+            LDNError::New(format!(
+                "Parse issue number: {} to u64 failed. {}",
+                issue_number, e
+            ))
+        })?;
+        self.github
+            .add_comment_to_issue(issue_number, &comment)
+            .await
+            .map_err(|e| {
+                LDNError::New(format!(
+                    "Error adding comment to issue {} /// {}",
+                    issue_number, e
+                ))
+            })?;
+
+        let app_state = if is_first {
+            AppState::Submitted.as_str()
+        } else {
+            AppState::Granted.as_str()
+        };
+        self.github
+            .replace_issue_labels(issue_number, &[app_state.into()])
+            .await
+            .map_err(|e| {
+                LDNError::New(format!(
+                    "Error adding labels to issue {} /// {}",
+                    issue_number, e
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn remove_first_pending_allocation(
+        &self,
+        application_file: &ApplicationFile,
+    ) -> Result<(), LDNError> {
+        let updated_application = application_file.move_back_to_governance_review();
+        self.update_and_commit_application_state(
+            updated_application.clone(),
+            self.github.owner.clone(),
+            self.github.repo.clone(),
+            self.file_sha.clone(),
+            LDNPullRequest::application_branch_name(&application_file.id),
+            self.file_name.clone(),
+            "Revert last pending allocation".to_string(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn remove_pending_refill(&self, pr_number: &i64) -> Result<(), LDNError> {
+        Self::delete_branch(
+            self.github.owner.clone(),
+            self.github.repo.clone(),
+            self.branch_name.clone(),
+        )
+        .await?;
+        database::applications::delete_application(
+            self.application_id.clone(),
+            self.github.owner.clone(),
+            self.github.repo.clone(),
+            *pr_number as u64,
+        )
+        .await
+        .map_err(|e| {
+            LDNError::New(format!(
+                "Removing application with PR number: {} failed. {:?}",
+                pr_number, e
+            ))
+        })?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Remove Pending Allocation

## Endpoint: [POST] verifier/application/remove_pending_allocation

**Description:**
This feature allows allocators to undo a pending DataCap allocation before the proposal. It helps correct any mistakes and ensures the accuracy of the allocation process.

The `verifier/application/remove_pending_allocation` endpoint receives query parameters (`VerifierActionsQueryParams`) to check if the caller is an allocator. Based on these query parameters, the endpoint performs the following checks:
- The current state of the application.
- The existence of an active pull request.
- Whether it is a first allocation or a refill allocation.

If the conditions are met, the endpoint performs the following actions:

### For the First Allocation:
- Reverts the application to the state it was in before starting the allocation.
- Comments on the relevant GitHub issue and sets the label to `validated`.
- Updates the record in the database.

### For the Refill Allocation:
- Deletes the active branch for the application.
- Deletes the active pull request for the application.
- Comments on the relevant GitHub issue and sets the label to `Granted`.
- Deletes the record in the database for the new allocation.

**Deployment Considerations:**
No special actions are required.