### PR TITLE
Add new endpoint to notify allocator that client used 75% of DataCap

### DIFF
--- a/fplus-http-server/src/main.rs
+++ b/fplus-http-server/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> std::io::Result<()> {
             .service(router::application::merged)
             .service(router::application::active)
             .service(router::application::all_applications)
-            .service(router::application::refill)
+            .service(router::application::notify_refill)
             .service(router::application::total_dc_reached)
             .service(router::application::single)
             .service(router::application::application_with_allocation_amount_handler)

--- a/fplus-http-server/src/router/application.rs
+++ b/fplus-http-server/src/router/application.rs
@@ -3,7 +3,7 @@ use fplus_lib::core::{
     application::file::VerifierInput, ApplicationQueryParams, BranchDeleteInfo,
     CompleteGovernanceReviewInfo, CompleteNewApplicationApprovalInfo,
     CompleteNewApplicationProposalInfo, CreateApplicationInfo, DcReachedInfo, GithubQueryParams,
-    LDNApplication, MoreInfoNeeded, RefillInfo, SubmitKYCInfo, TriggerSSAInfo,
+    LDNApplication, MoreInfoNeeded, NotifyRefillInfo, SubmitKYCInfo, TriggerSSAInfo,
     ValidationPullRequestData, VerifierActionsQueryParams,
 };
 
@@ -244,11 +244,11 @@ pub async fn merged(query: web::Query<GithubQueryParams>) -> actix_web::Result<i
     }
 }
 
-#[post("/application/refill")]
-pub async fn refill(data: web::Json<RefillInfo>) -> actix_web::Result<impl Responder> {
-    match LDNApplication::refill(data.into_inner()).await {
-        Ok(applications) => Ok(HttpResponse::Ok().json(applications)),
-        Err(e) => Ok(HttpResponse::BadRequest().body(e.to_string())),
+#[post("/application/notify_refill")]
+pub async fn notify_refill(info: web::Json<NotifyRefillInfo>) -> impl Responder {
+    match LDNApplication::notify_refill(info.into_inner()).await {
+        Ok(()) => HttpResponse::Ok().body(serde_json::to_string_pretty("Success").unwrap()),
+        Err(e) => HttpResponse::BadRequest().body(e.to_string()),
     }
 }
 

--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -117,6 +117,13 @@ pub struct RefillInfo {
 }
 
 #[derive(Deserialize)]
+pub struct NotifyRefillInfo {
+    pub owner: String,
+    pub repo: String,
+    pub issue_number: String,
+}
+
+#[derive(Deserialize)]
 pub struct DcReachedInfo {
     pub id: String,
     pub owner: String,
@@ -1513,7 +1520,7 @@ impl LDNApplication {
         Ok(apps)
     }
 
-    pub async fn refill(refill_info: RefillInfo) -> Result<bool, LDNError> {
+    async fn refill(refill_info: RefillInfo) -> Result<bool, LDNError> {
         let apps =
             LDNApplication::merged(refill_info.owner.clone(), refill_info.repo.clone()).await?;
         if let Some((content, mut app)) = apps.into_iter().find(|(_, app)| app.id == refill_info.id)
@@ -1548,6 +1555,28 @@ impl LDNApplication {
             return Ok(true);
         }
         Err(LDNError::Load("Failed to get application file".to_string()))
+    }
+
+    pub async fn notify_refill(info: NotifyRefillInfo) -> Result<(), LDNError> {
+        let comment = String::from(
+            "Client used 75% of the allocated DataCap. Consider allocating next tranche.",
+        );
+        Self::add_comment_to_issue(
+            info.issue_number.clone(),
+            info.owner.clone(),
+            info.repo.clone(),
+            comment,
+        )
+        .await?;
+        let label = "Refill needed";
+        Self::update_issue_labels(
+            info.issue_number.clone(),
+            &[label],
+            info.owner.clone(),
+            info.repo.clone(),
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn validate_merge_application(


### PR DESCRIPTION
# Add new endpoint to notify allocator that client used 75% of DataCap

## Endpoint: [POST] application/notify_refill

**Description:**
The endpoint is used by the SSA bot and, based on the data received, `NotifyRefillInfo` adds a comment to the related GitHub issue and changes the label to `Refill is needed`.

Additionally, the `/application/refill` endpoint has been removed as it is no longer needed. 

**Example NotifyRefillInfo:**

```json
{
    "owner": "repo_owner",
    "repo": "repo_name",
    "issue_number": "issue_number"
}
```

##  Deployment Considerations:
No special actions are required.