### PR TITLE
fix: Add github authentication to get_files_from_public_repo function

### DIFF
--- a/fplus-lib/src/external_services/github.rs
+++ b/fplus-lib/src/external_services/github.rs
@@ -739,13 +739,25 @@ impl GithubWrapper {
         branch: &str,
         path: Option<&str>,
     ) -> Result<ContentItems, OctocrabError> {
-        let octocrab = Octocrab::builder().build()?;
-        let gh = octocrab.repos(owner, repo);
-
         //if path is not provided, take all files from root
         let contents_items = match path {
-            Some(p) => gh.get_content().r#ref(branch).path(p).send().await?,
-            None => gh.get_content().r#ref(branch).send().await?,
+            Some(p) => {
+                self.inner
+                    .repos(owner, repo)
+                    .get_content()
+                    .r#ref(branch)
+                    .path(p)
+                    .send()
+                    .await?
+            }
+            None => {
+                self.inner
+                    .repos(owner, repo)
+                    .get_content()
+                    .r#ref(branch)
+                    .send()
+                    .await?
+            }
         };
 
         Ok(contents_items)


### PR DESCRIPTION
## Add GitHub authentication to get_files_from_public_repo() function.

**Description:**
Authentication with GitHub has been added to the `get_files_from_public_repo` function to avoid rate limits.

##  Deployment Considerations:
No special actions are required.