### PR TITLE
Fix repeated notifications about 75% reached

### DIFF
--- a/fplus-lib/src/external_services/github.rs
+++ b/fplus-lib/src/external_services/github.rs
@@ -261,6 +261,20 @@ impl GithubWrapper {
         Ok(())
     }
 
+    pub async fn issue_has_label(
+        &self,
+        number: u64,
+        expected_label: &str,
+    ) -> Result<bool, OctocrabError> {
+        let page = self
+            .inner
+            .issues(&self.owner, &self.repo)
+            .list_labels_for_issue(number)
+            .send()
+            .await?;
+        Ok(page.into_iter().any(|label| label.name == expected_label))
+    }
+
     pub async fn list_pull_requests(&self) -> Result<Vec<PullRequest>, OctocrabError> {
         let iid = self
             .inner


### PR DESCRIPTION
# Pull Request Template

## Description

Refill notifications triggered by SSA bot are being triggered every hour for the same application. This change makes sure they're only triggered once.


## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Staging env.

## Checklist:

Before submitting your pull request, please review the following checklist:

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.