### PR TITLE
Hotfix: support spaces in data amounts

### DIFF
--- a/fplus-lib/src/helpers.rs
+++ b/fplus-lib/src/helpers.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 
 pub fn parse_size_to_bytes(size: &str) -> Option<u64> {
-    let re = Regex::new(r"^(\d+)([a-zA-Z]+)$").unwrap();
+    let re = Regex::new(r"^(\d+)\s?([a-zA-Z]+)$").unwrap();
     let caps = re.captures(size.trim())?;
 
     let number = caps.get(1)?.as_str().parse::<u64>().ok()?;
@@ -62,4 +62,25 @@ pub fn process_amount(mut amount: String) -> String {
 
     // Replace 'b' with 'B'
     amount.replace('b', "B")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_size_to_bytes_should_work_with_whitespace() {
+        let res = parse_size_to_bytes("2 PiB");
+        assert_eq!(res, Some(2251799813685248));
+        let res = parse_size_to_bytes("2\tPiB");
+        assert_eq!(res, Some(2251799813685248));
+        let res = parse_size_to_bytes("2\nPiB");
+        assert_eq!(res, Some(2251799813685248));
+    }
+
+    #[test]
+    fn parse_size_to_bytes_should_work_without_whitespace() {
+        let res = parse_size_to_bytes("2PiB");
+        assert_eq!(res, Some(2251799813685248));
+    }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

There are applications that use spaces in data amounts in fields like "Total Requested DataCap". So applications with "2PiB" work, but "2 PiB" breaks some things. This PR fixes that.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests.

## Checklist:

Before submitting your pull request, please review the following checklist:

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.