### PR TITLE
Issue modification creates an application if do not exist

### DIFF
--- a/fplus-database/src/database/applications.rs
+++ b/fplus-database/src/database/applications.rs
@@ -24,7 +24,8 @@ pub async fn get_applications() -> Result<Vec<ApplicationModel>, sea_orm::DbErr>
                 a.id, 
                 a.owner, 
                 a.repo, 
-                a.pr_number, 
+                a.pr_number,
+                a.issue_number,
                 a.application, 
                 a.updated_at, 
                 a.sha,
@@ -50,6 +51,11 @@ pub async fn get_applications() -> Result<Vec<ApplicationModel>, sea_orm::DbErr>
             owner: app.get("owner").unwrap().as_str().unwrap().to_string(),
             repo: app.get("repo").unwrap().as_str().unwrap().to_string(),
             pr_number: app.get("pr_number").unwrap().as_i64().unwrap(),
+            issue_number: app
+                .get("issue_number")
+                .expect("Issue number should be in the application data")
+                .as_i64()
+                .expect("Issue number must exist"),
             application: Some(
                 app.get("application")
                     .unwrap()
@@ -210,6 +216,33 @@ pub async fn get_application_by_pr_number(
 }
 
 /**
+ * Get an application from the database with given issue_number
+ *
+ * # Arguments
+ * @param owner: String - The owner of the repository
+ * @param repo: String - The repository name
+ * @param issue_number: i64 - The issue number
+ *
+ * # Returns
+ * @return Result<ApplicationModel, sea_orm::DbErr> - The result of the operation
+ */
+pub async fn get_application_by_issue_number(
+    owner: String,
+    repo: String,
+    issue_number: i64,
+) -> Result<ApplicationModel, sea_orm::DbErr> {
+    let conn = get_database_connection().await?;
+
+    Application::find()
+        .filter(Column::Owner.eq(owner))
+        .filter(Column::Repo.eq(repo))
+        .filter(Column::IssueNumber.eq(issue_number))
+        .one(&conn)
+        .await?
+        .ok_or_else(|| DbErr::Custom("Application not found.".to_string()))
+}
+
+/**
  * Merge an application in the database
  *
  * # Arguments
@@ -323,7 +356,7 @@ pub async fn update_application(
             active_application.sha = Set(Some(file_sha));
             if let Some(path) = path {
                 active_application.path = Set(Some(path));
-            }
+            };
             let updated_application = active_application.update(&conn).await?;
             Ok(updated_application)
         }
@@ -353,6 +386,7 @@ pub async fn create_application(
     owner: String,
     repo: String,
     pr_number: u64,
+    issue_number: i64,
     app_file: String,
     path: String,
 ) -> Result<ApplicationModel, sea_orm::DbErr> {
@@ -368,6 +402,7 @@ pub async fn create_application(
         owner: Set(owner),
         repo: Set(repo),
         pr_number: Set(pr_number as i64),
+        issue_number: Set(issue_number),
         application: Set(Some(app_file)),
         sha: Set(Some(file_sha)),
         path: Set(Some(path)),

--- a/fplus-database/src/models/applications.rs
+++ b/fplus-database/src/models/applications.rs
@@ -15,6 +15,8 @@ pub struct Model {
     pub repo: String,
     #[sea_orm(primary_key, auto_increment = false)]
     pub pr_number: i64,
+    #[sea_orm(nullable)]
+    pub issue_number: i64,
     #[sea_orm(column_type = "Text", nullable)]
     pub application: Option<String>,
     #[sea_orm(nullable)]

--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -754,11 +754,18 @@ impl LDNApplication {
                     Ok(prs) => {
                         if let Some(pr) = prs.first() {
                             let number = pr.number;
+                            let issue_number = issue_number.parse::<i64>().map_err(|e| {
+                                LDNError::New(format!(
+                                    "Parse issue number: {} to i64 failed. {}",
+                                    issue_number, e
+                                ))
+                            })?;
                             database::applications::create_application(
                                 application_id.clone(),
                                 info.owner.clone(),
                                 info.repo.clone(),
                                 number,
+                                issue_number,
                                 file_content,
                                 LDNPullRequest::application_path(&app_id),
                             )
@@ -2354,11 +2361,18 @@ impl LDNApplication {
                 })?;
             }
             Err(_) => {
-                let _ = database::applications::create_application(
+                let issue_number = application_file.issue_number.parse::<i64>().map_err(|e| {
+                    LDNError::New(format!(
+                        "Parse issue number: {} to i64 failed. {}",
+                        application_file.issue_number, e
+                    ))
+                })?;
+                database::applications::create_application(
                     application_id,
                     owner.clone(),
                     repo.clone(),
                     pr_number,
+                    issue_number,
                     file_content.clone(),
                     filename.clone(),
                 )
@@ -2569,26 +2583,29 @@ impl LDNApplication {
         {
             Ok(app) => app,
             Err(e) => {
-                log::warn!("Failed to get application model: {}", e);
-
+                log::warn!("Failed to get application model: {}. ", e);
+                let parsed_issue_number = issue_number.parse::<i64>().map_err(|e| {
+                    LDNError::New(format!(
+                        "Parse issue number: {} to i64 failed. {}",
+                        issue_number, e
+                    ))
+                })?;
                 //Application Id has not been found. That means the user has modified the wallet address
-                LDNApplication::issue_error(
-                    issue_number.clone(),
+                let application = database::applications::get_application_by_issue_number(
                     info.owner.clone(),
                     info.repo.clone(),
-                    "Application not found. If you have modified the wallet address, please create a new application."
-                ).await?;
-                LDNApplication::add_error_label(
-                    issue_number.clone(),
-                    "".to_string(),
-                    info.owner.clone(),
-                    info.repo.clone(),
+                    parsed_issue_number,
                 )
-                .await?;
-                return Err(LDNError::New(format!(
-                    "Failed to get application model: {}",
-                    e
-                )));
+                .await;
+                if application.is_ok() {
+                    Self::add_comment_to_issue(issue_number, info.owner.clone(),info.repo.clone(), "Application exist. If you have modified the wallet address, please create a new application.".to_string()).await?;
+                    return Err(LDNError::New(format!(
+                        "Application exist: {}",
+                        application_id
+                    )));
+                } else {
+                    return Self::new_from_issue(info).await;
+                }
             }
         };
 
@@ -3267,25 +3284,6 @@ Your Datacap Allocation Request has been {} by the Notary
         Ok(true)
     }
 
-    async fn issue_error(
-        issue_number: String,
-        owner: String,
-        repo: String,
-        message: &str,
-    ) -> Result<bool, LDNError> {
-        let gh = github_async_new(owner, repo).await;
-        gh.add_comment_to_issue(issue_number.parse().unwrap(), message)
-            .await
-            .map_err(|e| {
-                LDNError::New(format!(
-                    "Error adding comment to issue {} /// {}",
-                    issue_number, e
-                ))
-            })
-            .unwrap();
-        Ok(true)
-    }
-
     async fn issue_additional_info_required(
         issue_number: String,
         owner: String,
@@ -3494,12 +3492,23 @@ _The initial issue can be edited in order to solve the request of the verifier. 
             if !db_apps_set.contains(&gh_app.application_file.id)
                 && !processed_gh_apps.contains(&gh_app.application_file.id)
             {
+                let issue_number = gh_app
+                    .application_file
+                    .issue_number
+                    .parse::<i64>()
+                    .map_err(|e| {
+                        LDNError::New(format!(
+                            "Parse issue number: {} to i64 failed. {}",
+                            gh_app.application_file.issue_number, e
+                        ))
+                    })?;
                 // Call the create_application function if the GH app is not in DB
                 database::applications::create_application(
                     gh_app.application_file.id.clone(),
                     owner.clone(),
                     repo.clone(),
                     gh_app.pr_number,
+                    issue_number,
                     serde_json::to_string_pretty(&gh_app.application_file).unwrap(),
                     gh_app.path,
                 )
@@ -3564,12 +3573,23 @@ _The initial issue can be edited in order to solve the request of the verifier. 
             if !db_apps_set.contains(&gh_app.application_file.id)
                 && !processed_gh_apps.contains(&gh_app.application_file.id)
             {
+                let issue_number = gh_app
+                    .application_file
+                    .issue_number
+                    .parse::<i64>()
+                    .map_err(|e| {
+                        LDNError::New(format!(
+                            "Parse issue number: {} to i64 failed. {}",
+                            gh_app.application_file.issue_number, e
+                        ))
+                    })?;
                 // Call the create_application function if the GH app is not in DB
                 database::applications::create_application(
                     gh_app.application_file.id.clone(),
                     owner.clone(),
                     repo.clone(),
                     0,
+                    issue_number,
                     serde_json::to_string_pretty(&gh_app.application_file).unwrap(),
                     gh_app.path,
                 )
@@ -4232,11 +4252,15 @@ impl LDNPullRequest {
         {
             Ok(pr) => {
                 if should_create_in_db {
+                    let issue_number = issue_number.parse::<i64>().map_err(|e| {
+                        LDNError::New(format!("Parse issue number to i64 failed: {}", e))
+                    })?;
                     database::applications::create_application(
                         application_id.clone(),
                         owner,
                         repo,
                         pr.0.number,
+                        issue_number,
                         file_content,
                         file_name,
                     )

--- a/manual-migrations/2024-07-23.sql
+++ b/manual-migrations/2024-07-23.sql
@@ -1,0 +1,11 @@
+ALTER TABLE applications
+    ADD COLUMN "issue_number" bigint;
+
+UPDATE applications SET issue_number = (application::json->>'Issue Number')::bigint;
+
+ALTER TABLE applications
+    ALTER COLUMN issue_number SET NOT NULL;
+
+CREATE UNIQUE INDEX application_owner_repo_issue_number_pr_number
+ON applications USING btree
+(owner, repo, issue_number, pr_number);


### PR DESCRIPTION
## Issue modification creates an application if do not exist

**Description:**
From now on, creating an application during issue modification is possible if it does not already exist.

A new field, `issue_number`, of type `bigint`, has been added to the database. This field will be used to check if an application already exists for an issue. 

A new unique index has been added to the database. This index ensures that an application cannot be created if one already exists with the same combination of repo, owner, pr_number, and issue_number.

##  Deployment Considerations:
Ensure that SQL code from migration files is executed in the exact order specified to avoid issues and maintain database integrity.

### SQL code to execute on the applications table:
```
ALTER TABLE applications
    ADD COLUMN "issue_number" bigint;

UPDATE applications SET issue_number = (application::json->>'Issue Number')::bigint;

ALTER TABLE applications
    ALTER COLUMN issue_number SET NOT NULL;

CREATE UNIQUE INDEX application_owner_repo_issue_number_pr_number
ON applications USING btree
(owner, repo, issue_number, pr_number);
```
