### PR TITLE
Add support for .filplusignore in Allocator repos

### DIFF
--- a/fplus-lib/src/core/allocator/mod.rs
+++ b/fplus-lib/src/core/allocator/mod.rs
@@ -473,7 +473,12 @@ pub async fn force_update_allocators(
 
         let gh = GithubWrapper::new(allocator.owner, allocator.repo, allocator.installation_id);
 
-        for file in files.iter() {
+        let ignored_files = gh.filplus_ignored_files(branch).await?;
+        log::debug!("List of ignored files: {ignored_files:?}");
+
+        let files = files.iter().filter(|f| !ignored_files.contains(f));
+
+        for file in files {
             match gh
                 .get_files_from_public_repo(
                     &allocator_template_owner,

--- a/fplus-lib/src/helpers.rs
+++ b/fplus-lib/src/helpers.rs
@@ -37,9 +37,7 @@ pub fn compare_allowance_and_allocation(
 
 pub fn process_amount(mut amount: String) -> String {
     // Trim 'S' or 's' from the end of the string
-    amount = amount
-        .trim_end_matches(|c: char| c == 'S' || c == 's')
-        .to_string();
+    amount = amount.trim_end_matches(['s', 'S']).to_string();
 
     // Replace 'b' with 'B'
     amount.replace('b', "B")


### PR DESCRIPTION
# Pull Request Template

## Description

Some allocators have a need to have different issue templates than the one in Allocator Template repo. However, even if they change it in their own repos, they will get overwritten sooner or later by the template.

This PR adds support for ".filplusignore" file in repos, that contains a list of files that shouldn't be copied from the template repo when updating the allocator.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Local build run against staging env.

## Checklist:

Before submitting your pull request, please review the following checklist:

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] Any dependent changes have been merged and published in downstream modules.

## Additional Information

None.