### PR TITLE
bugfix: approval validate returns False on total DC reached

### DIFF
--- a/fplus-lib/src/core/mod.rs
+++ b/fplus-lib/src/core/mod.rs
@@ -4463,6 +4463,17 @@ _The initial issue can be edited in order to solve the request of the verifier. 
 
         Ok(application_file)
     }
+
+    pub fn reached_total_datacap(self) -> Self {
+        let empty = "".to_string();
+
+        LifeCycle {
+            is_active: false,
+            updated_at: Utc::now().to_string(),
+            active_request: Some(empty),
+            ..self
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## Description

Due to application.Lifecycle["Active Request ID"] == "" approval validation is returning false. As the application.lifecycle.active flag is set to false, this validation shouldn't test anything more at all

Fixes # [(issue reference)](https://github.com/filecoin-project/filplus-backend/issues/107)

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [X] New and existing unit tests pass locally with my changes.